### PR TITLE
Simplified Language-Selection

### DIFF
--- a/src/main/java/org/openbase/bco/bcozy/controller/SettingsController.java
+++ b/src/main/java/org/openbase/bco/bcozy/controller/SettingsController.java
@@ -152,11 +152,9 @@ public class SettingsController {
             userSettingsController.initialize();
 
             this.userSettingsController.getThemeChoice().setOnAction(event -> chooseTheme());
-            this.userSettingsController.getLanguageChoice().setOnAction(event -> chooseLanguage());
 
             //Necessary to ensure that the first change is not missed by the ChangeListener
             this.userSettingsController.getThemeChoice().getSelectionModel().select(0);
-            this.userSettingsController.getLanguageChoice().getSelectionModel().select(0);
 
             return root;
         } catch (IOException ex) {
@@ -285,22 +283,6 @@ public class SettingsController {
                     }
                 });
     }
-
-    private void chooseLanguage() {
-        userSettingsController.getLanguageChoice().getSelectionModel().selectedIndexProperty()
-                .addListener(new ChangeListener<Number>() {
-
-                    @Override
-                    public void changed(final ObservableValue<? extends Number> observableValue, final Number number, final Number number2) {
-                        if (userSettingsController.getAvailableLanguages().get(number2.intValue()).equals("English")) {
-                            LanguageSelection.getInstance().setSelectedLocale(new Locale("en", "US"));
-                        } else if (userSettingsController.getAvailableLanguages().get(number2.intValue()).equals("Deutsch")) {
-                            LanguageSelection.getInstance().setSelectedLocale(new Locale("de", "DE"));
-                        }
-                    }
-                });
-    }
-
 
     private AnchorPane loadPermissionPane() {
         try {

--- a/src/main/java/org/openbase/bco/bcozy/controller/UserSettingsController.java
+++ b/src/main/java/org/openbase/bco/bcozy/controller/UserSettingsController.java
@@ -29,8 +29,12 @@ import javafx.scene.control.TitledPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.util.Duration;
+import javafx.util.StringConverter;
 import org.controlsfx.control.textfield.CustomTextField;
 import org.openbase.bco.authentication.lib.SessionManager;
+import org.openbase.bco.bcozy.model.LanguageSelection;
+import org.openbase.bco.bcozy.util.Language;
+import org.openbase.bco.bcozy.util.Languages;
 import org.openbase.bco.bcozy.view.*;
 import org.openbase.bco.registry.remote.Registries;
 import org.openbase.jul.exception.CouldNotPerformException;
@@ -73,7 +77,7 @@ public class UserSettingsController {
     @FXML
     private ChoiceBox<String> themeChoice;
     @FXML
-    private ChoiceBox<String> languageChoice;
+    private ChoiceBox<Language> languageChoice;
     @FXML
     private JFXCheckBox isOccupantField;
     @FXML
@@ -88,7 +92,7 @@ public class UserSettingsController {
     private ObserverButton savePassword;
 
     private ObservableList<String> availableThemes;
-    private ObservableList<String> availableLanguages;
+    private ObservableList<Language> availableLanguages;
     private final ForegroundPane foregroundPane;
 
     public UserSettingsController(ForegroundPane foregroundPane) {
@@ -107,16 +111,10 @@ public class UserSettingsController {
 
         initEditableFields(changeUsername, changeFirstname, changeLastname, changeMail, changePhone);
 
+        initializeLanguages();
 
         final ResourceBundle languageBundle = ResourceBundle
                 .getBundle(Constants.LANGUAGE_RESOURCE_BUNDLE, Locale.getDefault());
-
-        //TODO: Implement Property implementation
-
-        availableLanguages = FXCollections.observableArrayList("English", "Deutsch");
-        languageChoice.setItems(availableLanguages);
-
-
         availableThemes = FXCollections.observableArrayList(
                 languageBundle.getString(Constants.LIGHT_THEME_CSS_NAME),
                 languageBundle.getString(Constants.DARK_THEME_CSS_NAME));
@@ -127,6 +125,34 @@ public class UserSettingsController {
 
 
     }
+
+    /**
+     * Initializes the ChoiceBox, adds Listeners sets the current Language.
+     */
+    private void initializeLanguages() {
+        availableLanguages = FXCollections.observableList(Languages.getInstance().get());
+        languageChoice.setItems(availableLanguages);
+        languageChoice.setConverter(new StringConverter<Language>() {
+            @Override
+            public String toString(Language object) {
+                return object.getName();
+            }
+
+            @Override
+            public Language fromString(String string) {
+                return Languages.getInstance().get(string);
+            }
+        });
+        languageChoice.getSelectionModel().select(Languages.getInstance().get(Locale.getDefault()));
+        languageChoice.getSelectionModel().selectedItemProperty().addListener((observable, oldLocale, newLocale)
+                -> {
+            if (newLocale != null) {
+                LanguageSelection.getInstance().setSelectedLocale(newLocale.getLocale());
+            }
+        });
+
+    }
+
 
     private void updateOccupant(Boolean isOccupant) {
         try {
@@ -329,7 +355,7 @@ public class UserSettingsController {
      *
      * @return instance of the languageChoice
      */
-    public ChoiceBox<String> getLanguageChoice() {
+    public ChoiceBox<Language> getLanguageChoice() {
         return languageChoice;
     }
 
@@ -347,7 +373,7 @@ public class UserSettingsController {
      *
      * @return instance of the availableLanguages
      */
-    public ObservableList<String> getAvailableLanguages() {
+    public ObservableList<Language> getAvailableLanguages() {
         return availableLanguages;
     }
 

--- a/src/main/java/org/openbase/bco/bcozy/util/Language.java
+++ b/src/main/java/org/openbase/bco/bcozy/util/Language.java
@@ -1,0 +1,32 @@
+package org.openbase.bco.bcozy.util;
+
+import java.util.Locale;
+
+/**
+ * A language with given locale and name, eg "de_DE - Deutsch"
+ *
+ * @author vdasilva
+ */
+public class Language {
+
+    private final Locale locale;
+    private final String name;
+
+    public Language(Locale locale, String name) {
+        this.locale = locale;
+        this.name = name;
+    }
+
+    public Locale getLocale() {
+        return locale;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return locale + " - " + name;
+    }
+}

--- a/src/main/java/org/openbase/bco/bcozy/util/Languages.java
+++ b/src/main/java/org/openbase/bco/bcozy/util/Languages.java
@@ -31,15 +31,11 @@ public class Languages {
     private final List<Language> languages;
 
     /**
-     * Initializes Languages, either from available property-files or uses ["en_US","de_DE"].
+     * Initializes Languages from available property-files.
      */
     private Languages() {
         List<Locale> bundles = getLocalesFromBundles();
-        if (!bundles.isEmpty()) {
-            this.languages = bundles.stream().map(this::fromLocale).collect(Collectors.toList());
-        } else {
-            this.languages = Arrays.asList(english, fromLocale(Locale.GERMANY));
-        }
+        this.languages = bundles.stream().map(this::fromLocale).collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/org/openbase/bco/bcozy/util/Languages.java
+++ b/src/main/java/org/openbase/bco/bcozy/util/Languages.java
@@ -1,0 +1,128 @@
+package org.openbase.bco.bcozy.util;
+
+import java.io.File;
+import java.net.URL;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Class to hold available languages.
+ *
+ * @author vdasilva
+ */
+public class Languages {
+
+
+    /**
+     * Holder-Class for Threadsafe-Singleton.
+     */
+    private static final class InstanceHolder {
+        static final Languages INSTANCE = new Languages();
+    }
+
+    public static Languages getInstance() {
+        return InstanceHolder.INSTANCE;
+    }
+
+    private final Language english = fromLocale(Locale.US);
+
+    private final List<Language> languages;
+
+    /**
+     * Initializes Languages, either from available property-files or uses ["en_US","de_DE"].
+     */
+    private Languages() {
+        List<Locale> bundles = getLocalesFromBundles();
+        if (!bundles.isEmpty()) {
+            this.languages = bundles.stream().map(this::fromLocale).collect(Collectors.toList());
+        } else {
+            this.languages = Arrays.asList(english, fromLocale(Locale.GERMANY));
+        }
+    }
+
+    /**
+     * Creates a Language form the given Locale.
+     *
+     * @param locale
+     * @return
+     */
+    private Language fromLocale(Locale locale) {
+        return new Language(locale, locale.getDisplayLanguage(locale));
+    }
+
+    /**
+     * Creates Locales from each property-file available in "/languages".
+     *
+     * @return
+     */
+    private List<Locale> getLocalesFromBundles() {
+        List<String> matches = getFileMatches();
+        List<Locale> locales = new ArrayList<>(matches.size());
+        for (String match : matches) {
+            if (match.contains("_")) {
+                locales.add(new Locale(match.split("_")[0], match.split("_")[1]));
+            } else {
+                locales.add(new Locale(match));
+            }
+        }
+        return locales;
+    }
+
+    /**
+     * Gets all Language-Identifier (eg 'de', 'de_DE'), which have available property-files in "/languages".
+     *
+     * @return
+     */
+    private List<String> getFileMatches() {
+        List<String> matches = new LinkedList<>();
+        Pattern pattern = Pattern.compile("languages_(\\w+[_\\w+])\\.properties");
+        for (File file : getResourceFolderFiles("languages")) {
+            Matcher matcher = pattern.matcher(file.getName());
+            if (matcher.find()) {
+                matches.add(matcher.group(1));
+            }
+        }
+        return matches;
+    }
+
+    /**
+     * Gets all Files from an Resource-Directory.
+     *
+     * @param folder
+     * @return
+     */
+    private File[] getResourceFolderFiles(String folder) {
+        ClassLoader loader = Languages.class.getClassLoader();
+        URL url = loader.getResource(folder);
+        String path = url.getPath();
+        return new File(path).listFiles();
+    }
+
+    /**
+     * Returns the available Language with the locale or defaults to "en_US"
+     *
+     * @param locale
+     * @return
+     */
+    public Language get(Locale locale) {
+        return languages.stream().filter(l -> Objects.equals(l.getLocale(), locale))
+                .findAny().orElse(english);
+    }
+
+    /**
+     * Returns the available Language with the name or defaults to "en_US"
+     *
+     * @param name
+     * @return
+     */
+    public Language get(String name) {
+        return languages.stream().filter(l -> Objects.equals(l.getName(), name))
+                .findAny().orElse(english);
+    }
+
+    public List<Language> get() {
+        return languages;
+    }
+}

--- a/src/main/java/org/openbase/bco/bcozy/view/ObserverButton.java
+++ b/src/main/java/org/openbase/bco/bcozy/view/ObserverButton.java
@@ -1,17 +1,17 @@
 /**
  * ==================================================================
- *
+ * <p>
  * This file is part of org.openbase.bco.bcozy.
- *
+ * <p>
  * org.openbase.bco.bcozy is free software: you can redistribute it and modify
  * it under the terms of the GNU General Public License (Version 3)
  * as published by the Free Software Foundation.
- *
+ * <p>
  * org.openbase.bco.bcozy is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with org.openbase.bco.bcozy. If not, see <http://www.gnu.org/licenses/>.
  * ==================================================================
@@ -25,12 +25,9 @@ import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import org.openbase.bco.bcozy.model.LanguageSelection;
-import org.openbase.jul.exception.printer.ExceptionPrinter;
-import org.openbase.jul.exception.printer.LogLevel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Observable;
+import java.util.Observer;
 import java.util.function.Function;
 
 /**
@@ -41,12 +38,9 @@ import java.util.function.Function;
 @DefaultProperty("identifier")
 public class ObserverButton extends Button implements Observer {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ObserverButton.class);
-
     @FXML
     private SimpleStringProperty identifier = new SimpleStringProperty();
-    private ResourceBundle languageBundle = ResourceBundle
-            .getBundle(Constants.LANGUAGE_RESOURCE_BUNDLE, Locale.getDefault());
+
     /**
      * Is applied to new text when text is changed.
      */
@@ -90,16 +84,7 @@ public class ObserverButton extends Button implements Observer {
             return;
         }
 
-        String text;
-        try {
-            languageBundle = ResourceBundle.getBundle(Constants.LANGUAGE_RESOURCE_BUNDLE, Locale.getDefault());
-
-            text = languageBundle.getString(this.getIdentifier());
-        } catch (MissingResourceException ex) {
-            ExceptionPrinter.printHistory("Could not resolve Identifier[" + getIdentifier() + "]", ex, LOGGER,
-                    LogLevel.WARN);
-            text = getIdentifier();
-        }
+        String text = LanguageSelection.getLocalized(getIdentifier());
         super.setText(applyOnNewText.apply(text));
     }
 
@@ -117,6 +102,6 @@ public class ObserverButton extends Button implements Observer {
 
     public void setApplyOnNewText(Function<String, String> applyOnNewText) {
         this.applyOnNewText = applyOnNewText != null ? applyOnNewText : Function.identity();
-        this.update(null,null);
+        this.update(null, null);
     }
 }

--- a/src/main/java/org/openbase/bco/bcozy/view/ObserverButton.java
+++ b/src/main/java/org/openbase/bco/bcozy/view/ObserverButton.java
@@ -1,17 +1,17 @@
 /**
  * ==================================================================
- * <p>
+ *
  * This file is part of org.openbase.bco.bcozy.
- * <p>
+ *
  * org.openbase.bco.bcozy is free software: you can redistribute it and modify
  * it under the terms of the GNU General Public License (Version 3)
  * as published by the Free Software Foundation.
- * <p>
+ *
  * org.openbase.bco.bcozy is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * <p>
+ *
  * You should have received a copy of the GNU General Public License
  * along with org.openbase.bco.bcozy. If not, see <http://www.gnu.org/licenses/>.
  * ==================================================================

--- a/src/main/java/org/openbase/bco/bcozy/view/ObserverLabel.java
+++ b/src/main/java/org/openbase/bco/bcozy/view/ObserverLabel.java
@@ -24,12 +24,9 @@ import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
 import org.openbase.bco.bcozy.model.LanguageSelection;
-import org.openbase.jul.exception.printer.ExceptionPrinter;
-import org.openbase.jul.exception.printer.LogLevel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Observable;
+import java.util.Observer;
 import java.util.function.Function;
 
 /**
@@ -40,12 +37,8 @@ import java.util.function.Function;
 @DefaultProperty("identifier")
 public class ObserverLabel extends Label implements Observer {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ObserverLabel.class);
-
     @FXML
     private SimpleStringProperty identifier = new SimpleStringProperty();
-    private ResourceBundle languageBundle = ResourceBundle.getBundle(Constants.LANGUAGE_RESOURCE_BUNDLE, Locale.getDefault());
-
 
     /**
      * Is applied to new text when text is changed.
@@ -88,15 +81,8 @@ public class ObserverLabel extends Label implements Observer {
             return;
         }
 
-        String text;
-        try {
-            languageBundle = ResourceBundle.getBundle(Constants.LANGUAGE_RESOURCE_BUNDLE, Locale.getDefault());
+        String text = LanguageSelection.getLocalized(getIdentifier());
 
-            text = languageBundle.getString(this.getIdentifier());
-        } catch (MissingResourceException ex) {
-            ExceptionPrinter.printHistory("Could not resolve Identifier[" + getIdentifier() + "]", ex, LOGGER, LogLevel.WARN);
-            text = getIdentifier();
-        }
         super.setText(applyOnNewText.apply(text));
     }
 

--- a/src/main/java/org/openbase/bco/bcozy/view/ObserverText.java
+++ b/src/main/java/org/openbase/bco/bcozy/view/ObserverText.java
@@ -1,17 +1,17 @@
-/*
+/**
  * ==================================================================
- * 
+ *
  * This file is part of org.openbase.bco.bcozy.
- * 
+ *
  * org.openbase.bco.bcozy is free software: you can redistribute it and modify
  * it under the terms of the GNU General Public License (Version 3)
  * as published by the Free Software Foundation.
- * 
+ *
  * org.openbase.bco.bcozy is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with org.openbase.bco.bcozy. If not, see <http://www.gnu.org/licenses/>.
  * ==================================================================

--- a/src/main/java/org/openbase/bco/bcozy/view/ObserverText.java
+++ b/src/main/java/org/openbase/bco/bcozy/view/ObserverText.java
@@ -18,28 +18,40 @@
  */
 package org.openbase.bco.bcozy.view;
 
+import javafx.beans.DefaultProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.fxml.FXML;
 import javafx.scene.text.Text;
 import org.openbase.bco.bcozy.model.LanguageSelection;
-
-import java.util.Locale;
-import java.util.MissingResourceException;
-import java.util.Observable;
-import java.util.Observer;
-import java.util.ResourceBundle;
-import org.openbase.jul.exception.printer.ExceptionPrinter;
-import org.openbase.jul.exception.printer.LogLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Observable;
+import java.util.Observer;
+import java.util.function.Function;
+
 /**
  * Created by agatting on 13.04.16.
+ * @author vdasilva
  */
+@DefaultProperty("identifier")
 public class ObserverText extends Text implements Observer {
 
     protected final Logger LOGGER = LoggerFactory.getLogger(ObserverText.class);
 
-    private String identifier;
-    private ResourceBundle languageBundle = ResourceBundle.getBundle(Constants.LANGUAGE_RESOURCE_BUNDLE, Locale.getDefault());
+    @FXML
+    private SimpleStringProperty identifier = new SimpleStringProperty();
+
+    /**
+     * Is applied to new text when text is changed.
+     */
+    private Function<String, String> applyOnNewText = Function.identity();
+
+    public ObserverText() {
+        super();
+        identifier.addListener((observable, oldValue, newValue) -> update(null, null));
+        LanguageSelection.getInstance().addObserver(this);
+    }
 
     /**
      * Constructor to create a text which is capable of observing language changes in the application.
@@ -48,32 +60,40 @@ public class ObserverText extends Text implements Observer {
      * actual text
      */
     public ObserverText(final String identifier) {
-        super();
+        this();
         setIdentifier(identifier);
-        LanguageSelection.getInstance().addObserver(this);
-    }
-
-    /**
-     * Sets the new identifier for this ObserverText.
-     *
-     * @param identifier identifier
-     */
-    public void setIdentifier(final String identifier) {
-        this.identifier = identifier;
-        languageBundle = ResourceBundle.getBundle(Constants.LANGUAGE_RESOURCE_BUNDLE, Locale.getDefault());
-
-        try {
-            super.setText(languageBundle.getString(identifier));
-        } catch (MissingResourceException ex) {
-            if (!identifier.equals(Constants.DUMMY_LABEL)) {
-                ExceptionPrinter.printHistory("Could not resolve Identifier [" + identifier + "]!", ex, LOGGER, LogLevel.WARN);
-            }
-            super.setText(identifier);
-        }
     }
 
     @Override
     public void update(final Observable observable, final Object arg) {
-        setIdentifier(identifier);
+        if (getIdentifier() == null) {
+            return;
+        }
+
+        String text = LanguageSelection.getLocalized(getIdentifier());
+
+        super.setText(applyOnNewText.apply(text));
+    }
+
+    /**
+     * Sets the new identifier for this ObserverLabel.
+     *
+     * @param identifier identifier
+     */
+    public void setIdentifier(String identifier) {
+        this.identifier.set(identifier);
+    }
+
+    public String getIdentifier() {
+        return identifier.get();
+    }
+
+    public SimpleStringProperty identifierProperty() {
+        return identifier;
+    }
+
+    public void setApplyOnNewText(Function<String, String> applyOnNewText) {
+        this.applyOnNewText = applyOnNewText != null ? applyOnNewText : Function.identity();
+        this.update(null, null);
     }
 }

--- a/src/main/java/org/openbase/bco/bcozy/view/ObserverText.java
+++ b/src/main/java/org/openbase/bco/bcozy/view/ObserverText.java
@@ -1,17 +1,17 @@
-/**
+/*
  * ==================================================================
- * <p>
+ * 
  * This file is part of org.openbase.bco.bcozy.
- * <p>
+ * 
  * org.openbase.bco.bcozy is free software: you can redistribute it and modify
  * it under the terms of the GNU General Public License (Version 3)
  * as published by the Free Software Foundation.
- * <p>
+ * 
  * org.openbase.bco.bcozy is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * <p>
+ * 
  * You should have received a copy of the GNU General Public License
  * along with org.openbase.bco.bcozy. If not, see <http://www.gnu.org/licenses/>.
  * ==================================================================

--- a/src/main/java/org/openbase/bco/bcozy/view/ObserverText.java
+++ b/src/main/java/org/openbase/bco/bcozy/view/ObserverText.java
@@ -1,17 +1,17 @@
 /**
  * ==================================================================
- *
+ * <p>
  * This file is part of org.openbase.bco.bcozy.
- *
+ * <p>
  * org.openbase.bco.bcozy is free software: you can redistribute it and modify
  * it under the terms of the GNU General Public License (Version 3)
  * as published by the Free Software Foundation.
- *
+ * <p>
  * org.openbase.bco.bcozy is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with org.openbase.bco.bcozy. If not, see <http://www.gnu.org/licenses/>.
  * ==================================================================
@@ -66,6 +66,10 @@ public class ObserverText extends Text implements Observer {
 
     @Override
     public void update(final Observable observable, final Object arg) {
+        update();
+    }
+
+    public void update() {
         if (getIdentifier() == null) {
             return;
         }
@@ -94,6 +98,6 @@ public class ObserverText extends Text implements Observer {
 
     public void setApplyOnNewText(Function<String, String> applyOnNewText) {
         this.applyOnNewText = applyOnNewText != null ? applyOnNewText : Function.identity();
-        this.update(null, null);
+        this.update();
     }
 }


### PR DESCRIPTION
Languages are now provided in a list loaded from available property files instead of comparing strings when filling the language selection dropdown. 
Initially shown language is now correct. 